### PR TITLE
Add zero-fill to tensors

### DIFF
--- a/PhysicsTools/TensorFlow/bin/test_tftensor.cc
+++ b/PhysicsTools/TensorFlow/bin/test_tftensor.cc
@@ -73,7 +73,7 @@ int main(int argc, char* argv[])
 
 
     //
-    // test tensor tensor
+    // test scalar tensor
     //
 
     tf::Tensor* scalar = new tf::Tensor(0, 0);
@@ -111,6 +111,9 @@ int main(int argc, char* argv[])
     try { scalar->getPtrVectorAtPos<float>(0, 0); }
     catch (...) { catched = true; }
     test(catched, "scalar should not support pointer vector lookup");
+
+    scalar->fillValuesAtPos<float>((float)8., 0);
+    test(*scalar->getPtr<float>() == 8., "scalar value should be 8");
 
     delete scalar;
 
@@ -163,6 +166,11 @@ int main(int argc, char* argv[])
     vector->setVector<double>(vec1New);
     test(*vec1[3] == 8., "vector pointer vector element 3 should be 8");
 
+    vector->fillValues<double>(0, 2);
+    test(*vector->getPtr<double>(1) == 6., "vector value 1 should be 6");
+    test(*vector->getPtr<double>(2) == 0., "vector value 2 should be 0");
+    test(*vector->getPtr<double>(4) == 0., "vector value 4 should be 0");
+
     delete vector;
 
 
@@ -214,6 +222,11 @@ int main(int argc, char* argv[])
     matrix->setVector<float>(1, 3, vec2New);
     test(*vec2[4] == 9., "matrix pointer vector element 3,4 should be 9");
 
+    matrix->fillValues<float>(0, 3, 4);
+    test(*matrix->getPtr<float>(3, 3) == 8., "matrix value 3,3 should be 8");
+    test(*matrix->getPtr<float>(3, 4) == 0., "matrix value 3,4 should be 0");
+    test(*matrix->getPtr<float>(4, 7) == 0., "matrix value 4,7 should be 0");
+
     delete matrix;
 
 
@@ -264,6 +277,11 @@ int main(int argc, char* argv[])
     vec3New.push_back(19);
     tensor3->setVector<float>(2, 3, 4, vec3New);
     test(*vec3[10] == 15., "tensor3 pointer vector element 3,4,10 should be 15");
+
+    tensor3->fillValues<float>(0, 3, 4, 6);
+    test(*tensor3->getPtr<float>(3, 4, 5) == 10., "tensor3 value 3,4,5 should be 10");
+    test(*tensor3->getPtr<float>(3, 4, 6) == 0., "tensor3 value 3,4,6 should be 0");
+    test(*tensor3->getPtr<float>(4, 7, 14) == 0., "tensor3 value 4,7,14 should be 0");
 
     delete tensor3;
 

--- a/PhysicsTools/TensorFlow/bin/test_tftensor.cc
+++ b/PhysicsTools/TensorFlow/bin/test_tftensor.cc
@@ -112,7 +112,7 @@ int main(int argc, char* argv[])
     catch (...) { catched = true; }
     test(catched, "scalar should not support pointer vector lookup");
 
-    scalar->fillValuesAtPos<float>((float)8., 0);
+    scalar->fillValuesAtPos<float>((float)8., -1, 0);
     test(*scalar->getPtr<float>() == 8., "scalar value should be 8");
 
     delete scalar;
@@ -166,7 +166,7 @@ int main(int argc, char* argv[])
     vector->setVector<double>(vec1New);
     test(*vec1[3] == 8., "vector pointer vector element 3 should be 8");
 
-    vector->fillValues<double>(0, 2);
+    vector->fillValues<double>(0, -1, 2);
     test(*vector->getPtr<double>(1) == 6., "vector value 1 should be 6");
     test(*vector->getPtr<double>(2) == 0., "vector value 2 should be 0");
     test(*vector->getPtr<double>(4) == 0., "vector value 4 should be 0");
@@ -222,7 +222,7 @@ int main(int argc, char* argv[])
     matrix->setVector<float>(1, 3, vec2New);
     test(*vec2[4] == 9., "matrix pointer vector element 3,4 should be 9");
 
-    matrix->fillValues<float>(0, 3, 4);
+    matrix->fillValues<float>(0, -1, 3, 4);
     test(*matrix->getPtr<float>(3, 3) == 8., "matrix value 3,3 should be 8");
     test(*matrix->getPtr<float>(3, 4) == 0., "matrix value 3,4 should be 0");
     test(*matrix->getPtr<float>(4, 7) == 0., "matrix value 4,7 should be 0");
@@ -278,10 +278,18 @@ int main(int argc, char* argv[])
     tensor3->setVector<float>(2, 3, 4, vec3New);
     test(*vec3[10] == 15., "tensor3 pointer vector element 3,4,10 should be 15");
 
-    tensor3->fillValues<float>(0, 3, 4, 6);
+    tensor3->fillValues<float>(123, -1, 3, 4, 6);
+    test(*tensor3->getPtr<float>(3, 4, 5) == 10., "tensor3 value 3,4,5 should be 10");
+    test(*tensor3->getPtr<float>(3, 4, 6) == 123., "tensor3 value 3,4,6 should be 123");
+    test(*tensor3->getPtr<float>(3, 4, 7) == 123., "tensor3 value 3,4,7 should be 123");
+    test(*tensor3->getPtr<float>(3, 4, 8) == 123., "tensor3 value 3,4,8 should be 123");
+    test(*tensor3->getPtr<float>(4, 7, 14) == 123., "tensor3 value 4,7,14 should be 123");
+    tensor3->fillValues<float>(0, 2, 3, 4, 6);
     test(*tensor3->getPtr<float>(3, 4, 5) == 10., "tensor3 value 3,4,5 should be 10");
     test(*tensor3->getPtr<float>(3, 4, 6) == 0., "tensor3 value 3,4,6 should be 0");
-    test(*tensor3->getPtr<float>(4, 7, 14) == 0., "tensor3 value 4,7,14 should be 0");
+    test(*tensor3->getPtr<float>(3, 4, 7) == 0., "tensor3 value 3,4,7 should be 0");
+    test(*tensor3->getPtr<float>(3, 4, 8) == 123., "tensor3 value 3,4,8 should be 123");
+    test(*tensor3->getPtr<float>(4, 7, 14) == 123., "tensor3 value 4,7,14 should be 123");
 
     delete tensor3;
 

--- a/PhysicsTools/TensorFlow/interface/Graph.h
+++ b/PhysicsTools/TensorFlow/interface/Graph.h
@@ -1,5 +1,6 @@
 /*
  * TensorFlow graph interface.
+ * Based on TensorFlow C API 1.1.
  *
  * Author:
  *   Marcel Rieger

--- a/PhysicsTools/TensorFlow/interface/Tensor.h
+++ b/PhysicsTools/TensorFlow/interface/Tensor.h
@@ -278,44 +278,48 @@ public:
         setVectorAtPos<T>(axis, pos, v);
     }
 
-    // sets all elements to a constant value starting from a certain position
+    // sets n elements to a constant value starting from a certain position, negative n means all
     template <typename T>
-    void fillValuesAtPos(T v, Shape* pos);
+    void fillValuesAtPos(T v, int n, Shape* pos);
 
-    // sets all elements of a rank 1 tensor to a constant value starting from a certain position
+    // sets n elements of a rank 1 tensor to a constant value starting from a certain position,
+    // negative n means all
     template <typename T>
-    inline void fillValues(T v, Shape i)
+    inline void fillValues(T v, int n, Shape i)
     {
         assertRank(1);
         Shape pos[1] = { i };
-        fillValuesAtPos<T>(v, pos);
+        fillValuesAtPos<T>(v, n, pos);
     }
 
-    // sets all elements of a rank 2 tensor to a constant value starting from a certain position
+    // sets n elements of a rank 2 tensor to a constant value starting from a certain position,
+    // negative n means all
     template <typename T>
-    inline void fillValues(T v, Shape i, Shape j)
+    inline void fillValues(T v, int n, Shape i, Shape j)
     {
         assertRank(2);
         Shape pos[2] = { i, j };
-        fillValuesAtPos<T>(v, pos);
+        fillValuesAtPos<T>(v, n, pos);
     }
 
-    // sets all elements of a rank 3 tensor to a constant value starting from a certain position
+    // sets n elements of a rank 3 tensor to a constant value starting from a certain position,
+    // negative n means all
     template <typename T>
-    inline void fillValues(T v, Shape i, Shape j, Shape k)
+    inline void fillValues(T v, int n, Shape i, Shape j, Shape k)
     {
         assertRank(3);
         Shape pos[3] = { i, j, k };
-        fillValuesAtPos<T>(v, pos);
+        fillValuesAtPos<T>(v, n, pos);
     }
 
-    // sets all elements of a rank 4 tensor to a constant value starting from a certain position
+    // sets n elements of a rank 4 tensor to a constant value starting from a certain position,
+    // negative n means all
     template <typename T>
-    inline void fillValues(T v, Shape i, Shape j, Shape k, Shape l)
+    inline void fillValues(T v, int n, Shape i, Shape j, Shape k, Shape l)
     {
         assertRank(4);
         Shape pos[4] = { i, j, k, l };
-        fillValuesAtPos<T>(v, pos);
+        fillValuesAtPos<T>(v, n, pos);
     }
 
 private:
@@ -412,7 +416,7 @@ void Tensor::setVectorAtPos(int axis, Shape* pos, std::vector<T>& v)
 }
 
 template <typename T>
-void Tensor::fillValuesAtPos(T v, Shape* pos)
+void Tensor::fillValuesAtPos(T v, int n, Shape* pos)
 {
     // special treatment of scalars
     if (getRank() == 0)
@@ -421,8 +425,14 @@ void Tensor::fillValuesAtPos(T v, Shape* pos)
         return;
     }
 
-    // get the number of elements to fill
+    // get the maximum number of elements to fill
     int nElements = getShape(0) * prod[0] - getIndex(pos);
+
+    // limit by n
+    if (n >= 0 && n < nElements)
+    {
+        nElements = n;
+    }
 
     // set the values
     // here we exploit that the values we want to set are stored contiguously in the memory, so it

--- a/PhysicsTools/TensorFlow/src/Graph.cc
+++ b/PhysicsTools/TensorFlow/src/Graph.cc
@@ -1,5 +1,6 @@
 /*
  * TensorFlow graph interface.
+ * Based on TensorFlow C API 1.1.
  *
  * Author:
  *   Marcel Rieger

--- a/PhysicsTools/TensorFlow/src/Tensor.cc
+++ b/PhysicsTools/TensorFlow/src/Tensor.cc
@@ -1,5 +1,6 @@
 /*
  * TensorFlow tensor interface.
+ * Based on TensorFlow C API 1.1.
  *
  * Author:
  *   Marcel Rieger
@@ -62,7 +63,7 @@ void Tensor::init(TF_Tensor* t)
         }
         else
         {
-            prod[i] = prod[i+1] * getShape(i+1);
+            prod[i] = getShape(i+1) * prod[i+1];
         }
     }
 }
@@ -122,8 +123,8 @@ Shape Tensor::getIndex(Shape* pos) const
     // tensor's space to a 1D index representing the memory position is:
     // pos * prod (where both pos and prod are vectors/arrays)
     // prod is cached to increase performance and calculated via:
-    // prod_i = { 1               , i = rank - 1
-    //          { prod_{i+1}^rank , 0 <= i < rank - 1
+    // prod_i = { shape_{i+1} * prod_{i+1} , 0 <= i < rank - 1
+    //          { 1                        , i = rank - 1
 
     if (empty())
     {

--- a/RecoBTag/DeepFlavour/plugins/DeepFlavourJetTagProducer.cc
+++ b/RecoBTag/DeepFlavour/plugins/DeepFlavourJetTagProducer.cc
@@ -130,7 +130,7 @@ void DeepFlavourJetTagProducer::produce(edm::Event& iEvent, const edm::EventSetu
     {n_jets, 4, 12},      // input_4 - vertices 
     {n_jets, 1}           // input_5 - jet pt for reg 
   };
-  
+
   // initalize inputs
   for (std::size_t i=0; i < input_sizes.size(); i++) {
     auto & input_name = input_names_.at(i);
@@ -154,8 +154,10 @@ void DeepFlavourJetTagProducer::produce(edm::Event& iEvent, const edm::EventSetu
       c_pf_tensor_filler(dnn_inputs_.at(1), jet_n, c_pf_n, c_pf_features);
     }
     // fill remaining values with zeros
-    if (max_c_pf_n < (std::size_t)input_sizes.at(1).at(1)) {
-      dnn_inputs_.at(1)->fillValues<float>(0, jet_n, max_c_pf_n, 0);
+    std::size_t diff_c_pf_n = (std::size_t)input_sizes.at(1).at(1) - max_c_pf_n;
+    if (diff_c_pf_n > 0) {
+      dnn_inputs_.at(1)->fillValues<float>(0, diff_c_pf_n * (std::size_t)input_sizes.at(1).at(2),
+                                           jet_n, max_c_pf_n, 0);
     }
 
     // n_pf candidates
@@ -166,8 +168,10 @@ void DeepFlavourJetTagProducer::produce(edm::Event& iEvent, const edm::EventSetu
       n_pf_tensor_filler(dnn_inputs_.at(2), jet_n, n_pf_n, n_pf_features);
     }
     // fill remaining values with zeros
-    if (max_n_pf_n < (std::size_t)input_sizes.at(2).at(1)) {
-      dnn_inputs_.at(2)->fillValues<float>(0, jet_n, max_n_pf_n, 0);
+    std::size_t diff_n_pf_n = (std::size_t)input_sizes.at(2).at(1) - max_n_pf_n;
+    if (diff_n_pf_n > 0) {
+      dnn_inputs_.at(2)->fillValues<float>(0, diff_n_pf_n * (std::size_t)input_sizes.at(2).at(2),
+                                           jet_n, max_n_pf_n, 0);
     }
 
     // sv candidates
@@ -178,8 +182,10 @@ void DeepFlavourJetTagProducer::produce(edm::Event& iEvent, const edm::EventSetu
       sv_tensor_filler(dnn_inputs_.at(3), jet_n, sv_n, sv_features);
     }
     // fill remaining values with zeros
-    if (max_sv_n < (std::size_t)input_sizes.at(3).at(1)) {
-      dnn_inputs_.at(3)->fillValues<float>(0, jet_n, max_sv_n, 0);
+    std::size_t diff_sv_n = (std::size_t)input_sizes.at(3).at(1) - max_sv_n;
+    if (diff_sv_n > 0) {
+      dnn_inputs_.at(3)->fillValues<float>(0, diff_sv_n * (std::size_t)input_sizes.at(3).at(2),
+                                           jet_n, max_sv_n, 0);
     }
 
     // last input: corrected jet pt

--- a/RecoBTag/DeepFlavour/plugins/DeepFlavourJetTagProducer.cc
+++ b/RecoBTag/DeepFlavour/plugins/DeepFlavourJetTagProducer.cc
@@ -145,6 +145,7 @@ void DeepFlavourJetTagProducer::produce(edm::Event& iEvent, const edm::EventSetu
     // jet and other global features
     const auto & features = tag_infos->at(jet_n).features();
     jet_tensor_filler(dnn_inputs_.at(0), jet_n, features);
+
     // c_pf candidates
     auto max_c_pf_n = std::min(features.c_pf_features.size(),
                                (std::size_t) input_sizes.at(1).at(1));
@@ -152,6 +153,11 @@ void DeepFlavourJetTagProducer::produce(edm::Event& iEvent, const edm::EventSetu
       const auto & c_pf_features = features.c_pf_features.at(c_pf_n);
       c_pf_tensor_filler(dnn_inputs_.at(1), jet_n, c_pf_n, c_pf_features);
     }
+    // fill remaining values with zeros
+    if (max_c_pf_n < (std::size_t)input_sizes.at(1).at(1)) {
+      dnn_inputs_.at(1)->fillValues<float>(0, jet_n, max_c_pf_n, 0);
+    }
+
     // n_pf candidates
     auto max_n_pf_n = std::min(features.n_pf_features.size(),
                                (std::size_t) input_sizes.at(2).at(1));
@@ -159,6 +165,11 @@ void DeepFlavourJetTagProducer::produce(edm::Event& iEvent, const edm::EventSetu
       const auto & n_pf_features = features.n_pf_features.at(n_pf_n);
       n_pf_tensor_filler(dnn_inputs_.at(2), jet_n, n_pf_n, n_pf_features);
     }
+    // fill remaining values with zeros
+    if (max_n_pf_n < (std::size_t)input_sizes.at(2).at(1)) {
+      dnn_inputs_.at(2)->fillValues<float>(0, jet_n, max_n_pf_n, 0);
+    }
+
     // sv candidates
     auto max_sv_n = std::min(features.sv_features.size(),
                                (std::size_t) input_sizes.at(3).at(1));
@@ -166,6 +177,11 @@ void DeepFlavourJetTagProducer::produce(edm::Event& iEvent, const edm::EventSetu
       const auto & sv_features = features.sv_features.at(sv_n);
       sv_tensor_filler(dnn_inputs_.at(3), jet_n, sv_n, sv_features);
     }
+    // fill remaining values with zeros
+    if (max_sv_n < (std::size_t)input_sizes.at(3).at(1)) {
+      dnn_inputs_.at(3)->fillValues<float>(0, jet_n, max_sv_n, 0);
+    }
+
     // last input: corrected jet pt
     *dnn_inputs_.at(4)->getPtr<float>(jet_n, 0) = features.jet_features.corr_pt;
   }
@@ -192,7 +208,7 @@ void DeepFlavourJetTagProducer::produce(edm::Event& iEvent, const edm::EventSetu
       float o_sum = 0.;
       for (const unsigned int & ind : flav_pair.second) {
         o_sum += *dnn_outputs_.at(0)->getPtr<float>(jet_n, (tf::Shape)ind);
-      } 
+      }
       (*(output_tags.at(flav_n)))[jet_ref] = o_sum;
     }
   }


### PR DESCRIPTION
Input tensors 2, 3 and 4 have a [fixed size of axis 1](https://github.com/pablodecm/cmssw/blob/3a84742803b256373e46191bb40d42cafefc3475/RecoBTag/DeepFlavour/plugins/DeepFlavourJetTagProducer.cc#L128-L130). However, for some jets not all values are set due to a reduced number of charged/neutral pf candidates or vertices.

This PR adds
- a zero-filling (or any other value) feature to the underlying TensorFlow interface,
- and fills the above mentioned tensors with zeros.

As a result, no more NaN's emerge in the DNN output values.

