### PR TITLE
RECO-PAT agreement improvements

### DIFF
--- a/PhysicsTools/PatAlgos/python/tools/jetTools.py
+++ b/PhysicsTools/PatAlgos/python/tools/jetTools.py
@@ -547,7 +547,7 @@ def setupBTagging(process, jetSource, pfCandidates, explicitJTA, pvSource, svSou
                                       secondary_vertices=svSource,
                                       shallow_tag_infos = cms.InputTag(btagPrefix+'pfDeepCSVTagInfos'+labelName+postfix),
                                       puppi_value_map = "", # so it is not used
-                                      pvasq_value_map = "", # so it is not used
+                                      vertexAssociator = "", # so it is not used
                                       ),
                                     process, task)
 

--- a/RecoBTag/DeepFlavour/interface/c_pf_features_converter.h
+++ b/RecoBTag/DeepFlavour/interface/c_pf_features_converter.h
@@ -171,7 +171,7 @@ namespace deep {
             //c_pf_features.dz = c_pf->dz();
             c_pf_features.VTX_ass = (float) pat::PackedCandidate::PVAssociationQuality(qualityMap[pv_ass_quality]);
             if (c_pf->trackRef().isNonnull() && 
-                pv.trackWeight(c_pf->trackRef()) > 0.5 &&
+                pv->trackWeight(c_pf->trackRef()) > 0.5 &&
                 pv_ass_quality == 7) {
               c_pf_features.VTX_ass = (float) pat::PackedCandidate::UsedInFitTight;
             }

--- a/RecoBTag/DeepFlavour/interface/c_pf_features_converter.h
+++ b/RecoBTag/DeepFlavour/interface/c_pf_features_converter.h
@@ -129,13 +129,15 @@ namespace deep {
 
   template <typename CandidateType, typename JetType,
             typename TrackInfoBuilderType,
-            typename ChargedCandidateFeaturesType>
+            typename ChargedCandidateFeaturesType,
+            typename VertexType>
   void c_pf_reco_features_converter(const CandidateType * c_pf,
-                                     const JetType & jet,
-                                     const TrackInfoBuilderType & track_info,
-                                     const float & drminpfcandsv, const float & puppiw,
-                                     const int & pv_ass_quality,
-                                     ChargedCandidateFeaturesType & c_pf_features) {
+                                    const JetType & jet,
+                                    const TrackInfoBuilderType & track_info,
+                                    const float & drminpfcandsv, const float & puppiw,
+                                    const int & pv_ass_quality,
+                                    const VertexType & pv, 
+                                    ChargedCandidateFeaturesType & c_pf_features) {
 
             // track_info has to be built before passing as parameter
 
@@ -168,6 +170,11 @@ namespace deep {
 
             //c_pf_features.dz = c_pf->dz();
             c_pf_features.VTX_ass = (float) pat::PackedCandidate::PVAssociationQuality(qualityMap[pv_ass_quality]);
+            if (c_pf->trackRef().isNonnull() && 
+                pv.trackWeight(c_pf->trackRef()) > 0.5 &&
+                pv_ass_quality == 7) {
+              c_pf_features.VTX_ass = (float) pat::PackedCandidate::UsedInFitTight;
+            }
             //c_pf_features.fromPV = c_pf->fromPV();
             c_pf_features.vertexChi2=c_pf->vertexChi2();
             c_pf_features.vertexNdof=c_pf->vertexNdof();

--- a/RecoBTag/DeepFlavour/interface/c_pf_features_converter.h
+++ b/RecoBTag/DeepFlavour/interface/c_pf_features_converter.h
@@ -9,6 +9,13 @@ namespace deep {
   // conversion map from quality flags used in PV association and miniAOD one
   constexpr int qualityMap[8]  = {1,0,1,1,4,4,5,6};
 
+  enum qualityFlagsShiftsAndMasks {
+        assignmentQualityMask = 0x7, assignmentQualityShift = 0,
+        trackHighPurityMask  = 0x8, trackHighPurityShift=3,
+        lostInnerHitsMask = 0x30, lostInnerHitsShift=4,
+        muonFlagsMask = 0x0600, muonFlagsShift=9
+  };
+
 
   template <typename CandidateType, typename JetType,
             typename TrackInfoBuilderType,
@@ -226,13 +233,18 @@ namespace deep {
             c_pf_features.chi2 = deep::catch_infs_and_bound(std::floor(pseudo_track.normalizedChi2()),300,-1,300);
 
             // conditions from PackedCandidate producer
-            auto isHighPurity = c_pf->trackRef().isNonnull() && pseudo_track.quality(reco::Track::highPurity);
+            bool highPurity = c_pf->trackRef().isNonnull() && pseudo_track.quality(reco::Track::highPurity);
+            // do same bit operations than in PackedCandidate
+            uint16_t qualityFlags = 0;
+            qualityFlags = (qualityFlags & ~trackHighPurityMask) | ((highPurity << trackHighPurityShift) & trackHighPurityMask);
+            bool isHighPurity = (qualityFlags & trackHighPurityMask)>>trackHighPurityShift;
+            // to do as in TrackBase
+            uint8_t quality = (1 << reco::TrackBase::loose);
             if (isHighPurity) {
-              c_pf_features.quality = reco::TrackBase::highPurity;
-            } else {
-              c_pf_features.quality = reco::TrackBase::loose;
-            }
+              quality |= (1 << reco::TrackBase::highPurity);
+            } 
 
+            c_pf_features.quality = quality; 
             c_pf_features.drminsv = deep::catch_infs_and_bound(drminpfcandsv,0,-0.4,0,-0.4);
 
   } 

--- a/RecoBTag/DeepFlavour/plugins/DeepFlavourTagInfoProducer.cc
+++ b/RecoBTag/DeepFlavour/plugins/DeepFlavourTagInfoProducer.cc
@@ -261,7 +261,7 @@ void DeepFlavourTagInfoProducer::produce(edm::Event& iEvent, const edm::EventSet
         int pv_ass_quality = (*pvasq_value_map)[reco_ptr];
         deep::c_pf_reco_features_converter(reco_cand, jet, trackinfo, 
                                            drminpfcandsv, puppiw,
-                                           pv_ass_quality, c_pf_features);
+                                           pv_ass_quality, pv, c_pf_features);
         }
       }
     } else {

--- a/RecoBTag/DeepFlavour/plugins/DeepFlavourTagInfoProducer.cc
+++ b/RecoBTag/DeepFlavour/plugins/DeepFlavourTagInfoProducer.cc
@@ -28,8 +28,6 @@
 #include "RecoBTag/DeepFlavour/interface/TrackInfoBuilder.h"
 #include "RecoBTag/DeepFlavour/interface/sorting_modules.h"
 
-// conversion map from quality flags used in PV association and miniAOD one
-constexpr int qualityMap[8]  = {1,0,1,1,4,4,5,6};
 
 
 class DeepFlavourTagInfoProducer : public edm::stream::EDProducer<> {
@@ -260,8 +258,7 @@ void DeepFlavourTagInfoProducer::produce(edm::Event& iEvent, const edm::EventSet
         auto reco_ptr = pf_jet->getPFConstituent(i);
         // get PUPPI weight from value map
         float puppiw = (*puppi_value_map)[reco_ptr];
-        int quality = (*pvasq_value_map)[reco_ptr];
-        int pv_ass_quality = qualityMap[quality];
+        int pv_ass_quality = (*pvasq_value_map)[reco_ptr];
         deep::c_pf_reco_features_converter(reco_cand, jet, trackinfo, 
                                            drminpfcandsv, puppiw,
                                            pv_ass_quality, c_pf_features);

--- a/RecoBTag/DeepFlavour/python/DeepFlavourTagInfos_cfi.py
+++ b/RecoBTag/DeepFlavour/python/DeepFlavourTagInfos_cfi.py
@@ -7,6 +7,6 @@ pfDeepFlavourTagInfos = cms.EDProducer(
   secondary_vertices = cms.InputTag("inclusiveCandidateSecondaryVertices"),
   shallow_tag_infos = cms.InputTag('pfDeepCSVTagInfos'),
   puppi_value_map = cms.InputTag('puppi'),
-  pvasq_value_map = cms.InputTag('primaryVertexAssociation','original'),
+  vertexAssociator = cms.InputTag('primaryVertexAssociation','original'),
   jet_radius = cms.double(0.4)
 )


### PR DESCRIPTION
This PR will include modification over the DeepFlavourTagInfo produced that try to reduce the differences observed between the discriminator output observed when the sequence is run over MINIAOD jet collections and RECO jet collection, mainly attributed to the differences in the tracks from the charged candidates.

Summary of changes carried out:
- floor track chi2 for RECO
- initial quality fix